### PR TITLE
set up api route to get orders

### DIFF
--- a/client/Routes.js
+++ b/client/Routes.js
@@ -1,16 +1,16 @@
-
-import React, { Component, Fragment } from 'react';
-import { connect } from 'react-redux';
-import { withRouter, Route, Switch, Redirect } from 'react-router-dom';
-import { Login, Signup } from './components/AuthForm';
-import Home from './components/Home';
-import { me } from './store';
-import AllProduct from './components/AllProduct';
-import SingleProduct from './components/SingleProduct';
-import NewProduct from './components/NewProduct';
-import Cart from './components/Cart';
-import Users from './components/Users';
-import Confirmation from './components/OrderConfirmation';
+import React, { Component, Fragment } from "react";
+import { connect } from "react-redux";
+import { withRouter, Route, Switch, Redirect } from "react-router-dom";
+import { Login, Signup } from "./components/AuthForm";
+import Home from "./components/Home";
+import { me } from "./store";
+import AllProduct from "./components/AllProduct";
+import SingleProduct from "./components/SingleProduct";
+import NewProduct from "./components/NewProduct";
+import Cart from "./components/Cart";
+import Users from "./components/Users";
+import Confirmation from "./components/OrderConfirmation";
+import Orders from "./components/Orders";
 
 /**
  * COMPONENT
@@ -50,6 +50,7 @@ class Routes extends Component {
             render={() => (isAdmin && isLoggedIn ? <Users /> : null)}
           />
           <Route exact path="/cart" render={() => <Cart />} />
+          <Route exact path="/orders" render={() => <Orders />} />
           <Route exact path="/confirmation" render={() => <Confirmation />} />
         </Switch>
       </div>

--- a/client/components/Orders.js
+++ b/client/components/Orders.js
@@ -1,0 +1,55 @@
+import React from "react";
+import { connect } from "react-redux";
+import { fetchOrders } from "../store/orders";
+
+class Orders extends React.Component {
+  componentDidMount() {
+    this.props.getOrders();
+  }
+
+  render() {
+    console.log(this.props.orders);
+    return (
+      <div>
+        {this.props.orders &&
+          this.props.orders.map((order, idx) => {
+            let total = 0;
+            return (
+              <ul key={idx}>
+                <li>Order {idx + 1}:</li>
+                <li>Date: {order.order.updatedAt.slice(0, 10)}</li>
+                <li>
+                  Cocktails:
+                  {order.cocktails.map((cocktail) => {
+                    total += cocktail.price;
+                    return (
+                      <div key={cocktail.id}>
+                        <p>Name: {cocktail.name}</p>
+                        <p>Price: {cocktail.price}</p>
+                        {/* <img src={cocktail.imageUrl} alt={cocktail.name} /> */}
+                      </div>
+                    );
+                  })}
+                </li>
+                <li>Order Total: ${total}</li>
+              </ul>
+            );
+          })}
+      </div>
+    );
+  }
+}
+
+const mapState = (state) => {
+  return {
+    orders: state.orders,
+  };
+};
+
+const mapDispatch = (dispatch) => ({
+  getOrders: () => {
+    dispatch(fetchOrders());
+  },
+});
+
+export default connect(mapState, mapDispatch)(Orders);

--- a/client/store/index.js
+++ b/client/store/index.js
@@ -1,5 +1,3 @@
-
-
 import { createStore, combineReducers, applyMiddleware } from "redux";
 import { createLogger } from "redux-logger";
 import thunkMiddleware from "redux-thunk";
@@ -8,10 +6,9 @@ import auth from "./auth";
 import singleCocktail from "./singleproduct";
 import cocktailsReducer from "./allProduct";
 import createReducer from "./createProduct";
-import cartReducer from './cart';
+import cartReducer from "./cart";
 import usersReducer from "./user";
-
-
+import ordersReducer from "./orders";
 
 const reducer = combineReducers({
   auth,
@@ -22,6 +19,7 @@ const reducer = combineReducers({
   newCocktail: createReducer,
   cart: cartReducer,
   users: usersReducer,
+  orders: ordersReducer,
 });
 
 const middleware = composeWithDevTools(
@@ -30,4 +28,4 @@ const middleware = composeWithDevTools(
 const store = createStore(reducer, middleware);
 
 export default store;
-export * from './auth';
+export * from "./auth";

--- a/client/store/orders.js
+++ b/client/store/orders.js
@@ -1,0 +1,38 @@
+import axios from "axios";
+
+const GET_ORDERS = "GET ORDERS";
+
+const gotOrders = (orders) => ({
+  type: GET_ORDERS,
+  orders,
+});
+
+export const fetchOrders = () => async (dispatch) => {
+  try {
+    const token = window.localStorage.getItem("token");
+    if (token) {
+      const { data: orders } = await axios.get("/api/orders/", {
+        headers: {
+          authorization: token,
+        },
+      });
+
+      if (orders != null && orders != "null") {
+        dispatch(gotOrders(orders));
+      } else {
+        dispatch(gotOrders([]));
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+export default function ordersReducer(state = [], action) {
+  switch (action.type) {
+    case GET_ORDERS:
+      return action.orders;
+    default:
+      return state;
+  }
+}

--- a/server/api/index.js
+++ b/server/api/index.js
@@ -5,6 +5,7 @@ module.exports = router;
 
 router.use("/cocktails", require("./cocktails"));
 router.use("/cart", require("./cart"));
+router.use("/orders", require("./orders"));
 router.use("/users", require("./users"));
 router.use("/create-checkout-session", require("./create-checkout-session"));
 

--- a/server/api/orders.js
+++ b/server/api/orders.js
@@ -1,0 +1,35 @@
+const router = require("express").Router();
+const Sequelize = require("sequelize");
+const {
+  models: { Order, Order_items, Cocktail },
+} = require("../db");
+const { requireToken } = require("./gatekeeping");
+
+// GET api/orders
+router.get("/", requireToken, async (req, res, next) => {
+  try {
+    if (req.user) {
+      const orders = await Order.findAll({
+        where: {
+          [Sequelize.Op.and]: [{ userId: req.user.id }, { status: "complete" }],
+        },
+        include: Cocktail,
+      });
+
+      const formattedOrders = orders.map((order) => {
+        return {
+          order,
+          cocktails: order.cocktails,
+        };
+      });
+
+      res.json(formattedOrders);
+    } else {
+      res.send({ order: {}, cocktails: [] });
+    }
+  } catch (err) {
+    res.send({ order: {}, cocktails: [] });
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Added:

- get orders api route
- fetch orders thunk & reducer
- orders component on the front end

this is now rendering correct order data on the front end, but WITH NO FORMATTING. Did not yet add a link on the Navbar, you have to manually type /orders in the address bar to reach the page. Figured we can leave it this way until it's formatted. But for reference, it currently looks like this:

![Screen Shot 2021-07-27 at 11 32 13 AM](https://user-images.githubusercontent.com/79953082/127182976-cfb1eddf-3776-4cd9-b8ea-27b30a8a9615.png)
